### PR TITLE
Stable Install Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ test #1 "false" failed:
   The latest stable version:
 
   ```sh
-  $ wget git.io/aserta.stable && chmod +x aserta
+  $ wget git.io/aserta.stable -O aserta && chmod +x aserta
   ```
 
   The bleeding edge version (`master`):


### PR DESCRIPTION
When I tried to install the latest stable using the command in the readme this happened:

```
wget git.io/aserta.stable && chmod +x aserta
--2017-12-26 10:48:15--  http://git.io/aserta.stable
Resolving git.io (git.io)... 54.225.152.117, 54.225.177.165, 50.19.99.160, ...
Connecting to git.io (git.io)|54.225.152.117|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://git.io/aserta.stable [following]
--2017-12-26 10:48:15--  https://git.io/aserta.stable
Connecting to git.io (git.io)|54.225.152.117|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://raw.githubusercontent.com/andamira/aserta/stable/aserta [following]
--2017-12-26 10:48:15--  https://raw.githubusercontent.com/andamira/aserta/stable/aserta
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.116.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.116.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 13914 (14K) [text/plain]
Saving to: ‘aserta.stable’
aserta.stable                        100%[=====================================================================>]  13.59K  --.-KB/s    in 0.03s   

2017-12-26 10:48:15 (543 KB/s) - ‘aserta.stable’ saved [13914/13914]

chmod: cannot access 'aserta': No such file or directory
```

This is because wget downloads `aserta.stable` and not `aserta`. Fixed by adding the `-O` flag:

```
wget git.io/aserta.stable -O aserta && chmod +x aserta
URL transformed to HTTPS due to an HSTS policy
--2017-12-26 10:49:28--  https://git.io/aserta.stable
Resolving git.io (git.io)... 23.23.241.244, 50.19.99.160, 54.221.226.80, ...
Connecting to git.io (git.io)|23.23.241.244|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://raw.githubusercontent.com/andamira/aserta/stable/aserta [following]
--2017-12-26 10:49:28--  https://raw.githubusercontent.com/andamira/aserta/stable/aserta
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.116.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.116.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 13914 (14K) [text/plain]
Saving to: ‘aserta’

aserta                               100%[=====================================================================>]  13.59K  --.-KB/s    in 0.03s   

2017-12-26 10:49:28 (463 KB/s) - ‘aserta’ saved [13914/13914]
```
